### PR TITLE
Rename "modular-scale"

### DIFF
--- a/scss/_typeplate.scss
+++ b/scss/_typeplate.scss
@@ -148,7 +148,7 @@ $stats-border-style: 0.125rem solid #ccc;
 // --------------------------------------------------------------------------
 // http://thesassway.com/projects/modular-scale
 
-@function modular-scale($scale, $base, $value) {
+@function t-modular-scale($scale, $base, $value) {
 	// divide a given font-size by base font-size & return a relative em value
 	@return ($scale/$base)#{$value};
 }
@@ -173,7 +173,7 @@ $stats-border-style: 0.125rem solid #ccc;
 // $Typographic scale
 @mixin modular-scale($scale, $base, $value, $measure:"") {
 	font-size: $scale#{px};
-	font-size: modular-scale($scale, $base, $value);
+	font-size: t-modular-scale($scale, $base, $value);
 	@if $measure != "" {
 		margin-bottom: measure-margin($scale, $measure, $value);
 	}


### PR DESCRIPTION
What do you think about renaming the "modular-scale" function? 

Currently bourbon and compass already use them:
http://bourbon.io/docs/#modular-scale
http://thesassway.com/projects/modular-scale

Since you use either bourbon or compass (and not both) you won't have this conflict issue there. BUT you may want to use typeplate among side them (like me).

So either:
1) Rename the function to t-modular-scale. Should be okay since the function is slightly different.
2) Use bourbon/compass modular-scale function instead, but that would cause a requirement for the project (not cool)

In my case I need this change but I wish I wouldn't have to touch typeplate.scss and do my changes in different files for easier maintenance (such as updating typeplate).
