### PR TITLE
Adjusting readme path to work correctly for stylus

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,13 +31,13 @@ Yup that&rsquo;s right! We&rsquo;re in the bower package registry. Simply run ``
 
 	@import "compass";
 	@import "[your_project_path]/reset";
-	@import "[root_project_path]/components/scss/typeplate";
+	@import "[root_project_path]/components/typeplate/scss/typeplate";
 
 **LESS**
 
 	@import "compass";
 	@import "[your_project_path]/reset";
-	@import "[root_project_path]/components/less/typeplate.less";
+	@import "[root_project_path]/components/typeplate/less/typeplate.less";
 
 **Stylus**
 


### PR DESCRIPTION
I haven't changed the README for less and sass, but the root path into `components` needs to go into the `typeplate` folder for stylus, which I presume is also the case for SASS and LESS. I'll test those out and send out another patch when I'm sure that's the case. I removed the compass line, because stylus doesn't have compass (there are alternate frameworks like `nib` for stylus, but I don't think we need to add extra stuff if its not needed.
