### PR TITLE
Adjust readme to path correctly into the bower components folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,19 +31,18 @@ Yup that&rsquo;s right! We&rsquo;re in the bower package registry. Simply run ``
 
 	@import "compass";
 	@import "[your_project_path]/reset";
-	@import "[root_project_path]/components/scss/typeplate";
+	@import "[root_project_path]/components/typeplate/scss/typeplate";
 
 **LESS**
 
 	@import "compass";
 	@import "[your_project_path]/reset";
-	@import "[root_project_path]/components/less/typeplate.less";
+	@import "[root_project_path]/components/typeplate/less/typeplate.less";
 
 **Stylus**
 
-	@import "compass";
 	@import "[your_project_path]/reset";
-	@import "[root_project_path]/components/stylus/typeplate.styl";
+	@import "[root_project_path]/components/typeplate/stylus/typeplate.styl";
 
 **CSS**
 


### PR DESCRIPTION
Went ahead and changed this for less and sass, I'm pretty sure they
needed to be adjusted anyway.

Specifically adjusted README for stylus, there's no compass library so it didn't really make sense to leave it there.
