### PR TITLE
Fixing typeplate/typeplate.github.io#117

### DIFF
--- a/scss/_typeplate.scss
+++ b/scss/_typeplate.scss
@@ -2,13 +2,13 @@
  *
 .||..||..||..||..||..||..||..||..||..||..||..||..||..||..||..||..||..||..||.
 
-    .                                      '||            .
+	.                                      '||            .
   .||.  .... ... ... ...    ....  ... ...   ||   ....   .||.    ....
    ||    '|.  |   ||'  || .|...||  ||'  ||  ||  '' .||   ||   .|...||
    ||     '|.|    ||    | ||       ||    |  ||  .|' ||   ||   ||
    '|.'    '|     ||...'   '|...'  ||...'  .||. '|..'|'  '|.'  '|...'
-        .. |      ||               ||
-         ''      ''''             ''''      A Typographic Starter Kit
+		.. |      ||               ||
+		 ''      ''''             ''''      A Typographic Starter Kit
 
   URL ........... http://typeplate.com
   VERSION ....... 1.1.0
@@ -32,19 +32,18 @@
 
 // $Variable $BaseType
 // -------------------------------------//
+//the serif boolean var can be redeclared from another stylesheet. However
+//the var must be placed after your @import "typeplate.scss";
+$serif-boolean: true !default;
+
+$font-family: if($serif-boolean, serif, sans-serif) !default; // Non-font-face font-stack
 
 $font-weight: normal !default;
 $line-height: 1.65 !default;
 $font-size: 112.5 !default; // percentage value (16 * 112.5% = 18px)
 $font-base: 16 * ($font-size/100) !default; // converts our percentage to a pixel value
+$custom-font-family: false !default; // Font-face stack, if set will be added to the $base-font-family
 $measure: $font-base * $line-height;
-$font-family: serif;
-$font-family-sans: sans-serif;
-$font-properties: $font-weight, $line-height, $font-size, $font-family;
-
-//the serif boolean var can be redeclared from another stylesheet. However
-//the var must be placed after your @import "typeplate.scss";
-$serif-boolean: true !default;
 
 
 // $Variable $Small-Print
@@ -246,19 +245,6 @@ $dropcap-bg: transparent !default;
 		margin-bottom: measure-margin($scale, $measure, $value);
 	}
 }
-
-
-// $Mixin $Body-Copy
-// -------------------------------------//
-
-@mixin base-type($font-weight, $line-height, $font-size, $font-family...) {
-	@if $serif-boolean {
-		font: $font-weight #{$font-size}%/#{$line-height} $font-family;
-	}@else {
-		font: $font-weight #{$font-size}%/#{$line-height} $font-family-sans;
-	}
-}
-
 
 // $Mixin $Hypens
 // -------------------------------------//
@@ -527,7 +513,11 @@ $dropcap-bg: transparent !default;
 // -------------------------------------//
 
 html {
-	@include base-type($font-properties...);
+	@if $custom-font-family {
+		font: $font-weight #{$font-size}%/#{$line-height} $custom-font-family, $font-family;
+	} @else {
+		font: $font-weight #{$font-size}%/#{$line-height} $font-family;
+	}
 }
 
 body {

--- a/scss/_vars-typeplate.scss
+++ b/scss/_vars-typeplate.scss
@@ -1,13 +1,13 @@
 // .||..||..||..||..||..||..||..||..||..||..||..||..||..||..||..||..||.
 
-//   .                                      '||            .           
-// .||.  .... ... ... ...    ....  ... ...   ||   ....   .||.    ....  
-//  ||    '|.  |   ||'  || .|...||  ||'  ||  ||  '' .||   ||   .|...|| 
-//  ||     '|.|    ||    | ||       ||    |  ||  .|' ||   ||   ||      
-//  '|.'    '|     ||...'   '|...'  ||...'  .||. '|..'|'  '|.'  '|...' 
-//       .. |      ||               ||                                 
+//   .                                      '||            .
+// .||.  .... ... ... ...    ....  ... ...   ||   ....   .||.    ....
+//  ||    '|.  |   ||'  || .|...||  ||'  ||  ||  '' .||   ||   .|...||
+//  ||     '|.|    ||    | ||       ||    |  ||  .|' ||   ||   ||
+//  '|.'    '|     ||...'   '|...'  ||...'  .||. '|..'|'  '|.'  '|...'
+//       .. |      ||               ||
 //        ''      ''''             ''''                      VARIABLES
-// 
+//
 
 // .||..||..||..||..||..||..||..||..||..||..||..||..||..||..||..||..||.
 
@@ -20,7 +20,9 @@ $font-weight: normal;
 $line-height: 1.65;
 $font-size: 112.5; // percentage value (16 * 112.5% = 18px)
 $font-base: 16 * ($font-size/100); // converts our percentage to a pixel value
-$serif-boolean: true; // declares serif or sans-serif for your default type
+$font-family: serif; // Non-font-face font-stack
+
+$custom-font-family: false; // Font-face stack, if set will be added to the $base-font-family
 
 
 // $Small Print


### PR DESCRIPTION
The serif-boolean is kept for backwards compatibility
