### PR TITLE
Allow Typeplate to compile with libsass

### DIFF
--- a/scss/_typeplate.scss
+++ b/scss/_typeplate.scss
@@ -513,9 +513,9 @@ $dropcap-bg: transparent !default;
 
 html {
 	@if $custom-font-family {
-		font: $font-weight #{$font-size}%/#{$line-height} $custom-font-family, $font-family;
+		font: $font-weight #{$font-size + "%"}/#{$line-height} $custom-font-family, $font-family;
 	} @else {
-		font: $font-weight #{$font-size}%/#{$line-height} $font-family;
+		font: $font-weight #{$font-size + "%"}/#{$line-height} $font-family;
 	}
 }
 


### PR DESCRIPTION
Move the `%` for the global `font-size` into the interpolation construct, so that the symbol is unambiguously part of the value, instead of possibly an operator.

Tested with Sass 3.3.3 and [libsass-python](https://github.com/dahlia/libsass-python) 0.3.0.
