### PR TITLE
fixed: whitespaces between value and unit break on chrome.

### DIFF
--- a/scss/_typeplate.scss
+++ b/scss/_typeplate.scss
@@ -202,7 +202,7 @@ $dropcap-bg: transparent !default;
 // divide a given font-size by base font-size & return a relative value
 
 @function context-calc($scale, $base, $value) {
-	@return ($scale/$base)#{$value};
+	@return ($scale/$base)+#{$value};
 }
 
 
@@ -215,11 +215,11 @@ $dropcap-bg: transparent !default;
 	$remValue: $pixelValue * $font-base;
 
 	@if $value == rem {
-		@return $pixelValue#{$value};
+		@return $pixelValue+#{$value};
 	} @else if $value == em {
-		@return ($remValue/$scale)#{$value};
+		@return ($remValue/$scale)+#{$value};
 	} @else {
-		@return $remValue#{$value};
+		@return $remValue+#{$value};
 	}
 }
 
@@ -236,12 +236,12 @@ $dropcap-bg: transparent !default;
 
 @mixin type-scale($scale, $base, $value, $measure:"") {
 	@if $value == rem {
-		font-size: $scale#{px};
+		font-size: $scale+#{px};
 		font-size: context-calc($scale, $base, $value);
 	} @else if $value == em {
 		font-size: context-calc($scale, $base, $value);
 	} @else {
-		font-size: $scale#{px};
+		font-size: $scale+#{px};
 	}
 
 	@if $measure != "" {


### PR DESCRIPTION
Hi,

I just encountered this issue when using the sass version of Typeplate. The compiled source looks like this for value/unit selectors declarations: `font-size: 60 px`  The space between value and unit causes Chrome to ignore the declaration.

Cause: the whitespace is introduced when performing a division operation on two values.
Fix: use the concatenation value between unit and value to get rid of the extra whitespace.

See: 
https://stackoverflow.com/questions/10890445/how-do-i-stop-sass-adding-spaces-before-units-of-measurement
http://sass-lang.com/documentation/file.SASS_REFERENCE.html#string_operations

PS: I'm compiling my sass with grunt-sass 0.16.0 and looking at my generated CSS with Chrome 38.
