### PR TITLE
fix sass compile GBK issue on Windows7

### DIFF
--- a/scss/_typeplate-helpers.scss
+++ b/scss/_typeplate-helpers.scss
@@ -131,7 +131,7 @@ p + .typl8-drop-cap {
     <p><sup><a href="#fn-itemX" id="fn-returnX"></a></sup></p>
     <footer>
       <ol class="foot-notes">
-        <li id="fn-itemX"><a href="#fn-returnX">↩</a></li>
+        <li id="fn-itemX"><a href="#fn-returnX">\u21a9</a></li>
       </ol>
     </footer>
   </article>

--- a/scss/_typeplate-mixins.scss
+++ b/scss/_typeplate-mixins.scss
@@ -164,13 +164,13 @@
   }
 
   &:before {
-    content: '“';
+    content: '\u201c';
     top:  0;
     left: 0;
   }
 
   &:after {
-    content: '”';
+    content: '\u201d';
     bottom: 0;
     right: 0;
   }


### PR DESCRIPTION
Sass version: 3.4.21
Gem version: 2.4.5.1
Ruby version: 2.2.3p173

When I want to using `sass` command `sass _typeplate-index.scss:style.css` in cmd for compiling the `typeplate-index.scss` file, the cmd show me the error:

> Error: Invalid GBK character "\xE2"
>         on line 173 of _typeplate-mixins.scss
>         from line 14 of _typeplate-index.scss
>   Use --trace for backtrace.

It seems the GBK character `“` cause the problem. One solution  I add encoding option at the end of the compile command.

Another solution is convert the GBK character to the unicode character.
